### PR TITLE
cut uri due to RFC doc

### DIFF
--- a/docs/interfaces/AuthorizationCodeGrantOptions.md
+++ b/docs/interfaces/AuthorizationCodeGrantOptions.md
@@ -8,6 +8,14 @@ Support from the community to continue maintaining and improving this module is 
 
 ## Properties
 
+### cutUri?
+
+• `optional` **cutUri**: `boolean`
+
+cutUri will cut URI search params and last slash, before passing it on token endpoint.
+
+***
+
 ### DPoP?
 
 • `optional` **DPoP**: [`DPoPHandle`](DPoPHandle.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2488,6 +2488,10 @@ export interface AuthorizationCodeGrantOptions extends DPoPOptions {
    * @internal
    */
   redirectUri?: string
+  /**
+   * cutUri will cut URI search params and last slash, before passing it on token endpoint.
+   */
+  cutUri?: boolean
 }
 
 /**
@@ -3322,7 +3326,7 @@ export async function authorizationCodeGrant(
       c,
       auth,
       authResponse,
-      redirectUri,
+      options?.cutUri ? cleanUrl(redirectUri) : redirectUri,
       // @ts-expect-error
       checks?.pkceCodeVerifier || oauth._nopkce,
       {
@@ -4326,3 +4330,16 @@ export async function fetchProtectedResource(
  */
 export interface DeviceAutorizationGrantPollOptions
   extends DeviceAuthorizationGrantPollOptions {}
+
+function cleanUrl(input: string) {
+  const url = new URL(input);
+  url.search = ""; // removes all search params
+
+  let href = url.toString();
+
+  if (href.endsWith("/")) {
+    href = href.slice(0, -1); // remove trailing slash
+  }
+
+  return href;
+}


### PR DESCRIPTION
Good day, I am looking to add my code to openid-client due to a misunderstanding of redirect URI usage
https://www.rfc-editor.org/rfc/rfc9449.html#section-12.7-3.2.2.4
you see
<img width="706" alt="Screenshot 2025-06-05 at 14 37 53" src="https://github.com/user-attachments/assets/306c1ec2-fb46-4b88-8341-f14b5cfc8f9d" />
According to RFC, the URI on the token endpoint is not supposed to have any kind of search parameters. The field where I am using your client is very strict, I am doing such code 
<img width="716" alt="Screenshot 2025-06-05 at 14 43 52" src="https://github.com/user-attachments/assets/13a7e1dc-dd96-4f35-8ca7-25a735ffe75e" />
I am using the exact path of the current URL, since you want to check my search params locally in JavaScript, and if there is none, you are throwing 
**no authorization code in "callbackParameters"**
However, when I am adding them all to your request, I receive **"Redirect URI is invalid"** from my OAuth service.
I kindly suggest adding an option that could either continue your flow of checking that search params are legit, but also do not pass them into the OAuth backend.


Best regards.