### PR TITLE
fix: add `undefined` check in `selectCryptoKeyForDecryption`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1614,11 +1614,11 @@ function selectCryptoKeyForDecryption(
   epk?: unknown,
 ): CryptoKey {
   const { 0: key, length } = keys.filter((key) => {
-    if (kid !== key.kid) {
+    if (key.kid !== undefined && kid !== key.kid) {
       return false
     }
 
-    if (key.alg && alg !== key.alg) {
+    if (key.alg !== undefined && alg !== key.alg) {
       return false
     }
 


### PR DESCRIPTION
Resolves issue [#797](https://github.com/panva/openid-client/issues/797).

- Adds an `undefined` check for `key.kid`, and
- Makes the `undefined` check explicit for `key.alg`.