### PR TITLE
Ignore trailing back-slashes when comparing issuer urls during discovery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1393,7 +1393,7 @@ async function performDiscovery(
     )
     .catch(errorHandler)
 
-  if (resolve && new URL(as.issuer).href !== server.href) {
+  if (resolve && stripTrailingSlash(new URL(as.issuer).href) !== stripTrailingSlash(server.href)) {
     handleEntraId(server, as, options) ||
       handleB2Clogin(server, options) ||
       (() => {
@@ -3156,6 +3156,10 @@ function stripParams(url: URL) {
   url.search = ''
   url.hash = ''
   return url.href
+}
+
+function stripTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 
 function webInstanceOf<T>(input: unknown, toStringTag: string): input is T {


### PR DESCRIPTION
This resolves an issue when using openid-client to perform discovery on Keycloak:
- openid-client is only able to resolve the issuer url if it ends with slash.
- keycloak returns the issuer url without the trailing slash.

This commit ignores trailing slash in the issuer url comparison.