### PR TITLE
Allow passing URLSearchParams directly to implicitAuthentication

### DIFF
--- a/docs/functions/implicitAuthentication.md
+++ b/docs/functions/implicitAuthentication.md
@@ -25,7 +25,7 @@ Response.
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `config` | [`Configuration`](../classes/Configuration.md) | - |
-| `currentUrl` | [`URL`](https://developer.mozilla.org/docs/Web/API/URL) \| [`Request`](https://developer.mozilla.org/docs/Web/API/Request) | Current [URL](https://developer.mozilla.org/docs/Web/API/URL) the Authorization Server provided an Authorization Response to or a [Request](https://developer.mozilla.org/docs/Web/API/Request), the [Authentication Response Parameters](https://openid.net/specs/openid-connect-core-1_0-errata2.html#ImplicitAuthResponse) are extracted from this. |
+| `currentUrl` | [`URL`](https://developer.mozilla.org/docs/Web/API/URL) \| [`URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams) \| [`Request`](https://developer.mozilla.org/docs/Web/API/Request) | Current [URL](https://developer.mozilla.org/docs/Web/API/URL) the Authorization Server provided an Authorization Response to or a [Request](https://developer.mozilla.org/docs/Web/API/Request), the [Authentication Response Parameters](https://openid.net/specs/openid-connect-core-1_0-errata2.html#ImplicitAuthResponse) are extracted from this. |
 | `expectedNonce` | `string` | Expected value of the `nonce` ID Token claim. This value must match exactly. |
 | `checks`? | [`ImplicitAuthenticationResponseChecks`](../interfaces/ImplicitAuthenticationResponseChecks.md) | Additional optional Implicit Authentication Response checks |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2854,7 +2854,8 @@ export interface ImplicitAuthenticationResponseChecks
  * ```
  *
  * @param currentUrl Current {@link !URL} the Authorization Server provided an
- *   Authorization Response to or a {@link !Request}, the
+ *   Authorization Response, or a {@link !URLSearchParams}, or a {@link !Request}.
+ *   The
  *   {@link https://openid.net/specs/openid-connect-core-1_0-errata2.html#ImplicitAuthResponse Authentication Response Parameters}
  *   are extracted from this.
  * @param expectedNonce Expected value of the `nonce` ID Token claim. This value
@@ -2869,7 +2870,7 @@ export interface ImplicitAuthenticationResponseChecks
  */
 export async function implicitAuthentication(
   config: Configuration,
-  currentUrl: URL | Request,
+  currentUrl: URL | URLSearchParams | Request,
   expectedNonce: string,
   checks?: ImplicitAuthenticationResponseChecks,
 ): Promise<oauth.IDToken> {
@@ -2877,10 +2878,11 @@ export async function implicitAuthentication(
 
   if (
     !(currentUrl instanceof URL) &&
+    !(currentUrl instanceof URLSearchParams) &&
     !webInstanceOf<Request>(currentUrl, 'Request')
   ) {
     throw CodedTypeError(
-      '"currentUrl" must be an instance of URL, or Request',
+      '"currentUrl" must be an instance of URL, or URLSearchParams, or Request',
       ERR_INVALID_ARG_TYPE,
     )
   }
@@ -2902,7 +2904,9 @@ export async function implicitAuthentication(
   }
 
   let params: URLSearchParams
-  if (!(currentUrl instanceof URL)) {
+  if (currentUrl instanceof URLSearchParams) {
+    params = currentUrl
+  } else if (!(currentUrl instanceof URL)) {
     const request: Request = currentUrl
     switch (request.method) {
       case 'GET':

--- a/tap/end2end.ts
+++ b/tap/end2end.ts
@@ -242,7 +242,7 @@ export default (QUnit: QUnit) => {
         )
       }
 
-      let input: URL | Request
+      let input: URL | URLSearchParams | Request
       if (form_post) {
         input = new Request(
           `${currentUrl.protocol}//${currentUrl.host}${currentUrl.pathname}`,
@@ -258,9 +258,14 @@ export default (QUnit: QUnit) => {
           },
         )
       } else {
-        switch ([URL, Request][Math.floor(Math.random() * 2)]) {
+        switch (
+          [URL, URLSearchParams, Request][Math.floor(Math.random() * 2)]
+        ) {
           case URL:
             input = currentUrl
+            break
+          case URLSearchParams:
+            input = new URLSearchParams(new URL(currentUrl).hash.slice(1))
             break
           case Request:
             input = new Request(currentUrl)


### PR DESCRIPTION
Given that the function is already using `URLSearchParams` internally, it seems like a natural extension to allow one to pass an instance of `URLSearchParams` if they already have it. This makes `implicitAuthentication` usable even when one doesn't have a web `Request` object. 